### PR TITLE
Fix for AMD family 15 detection

### DIFF
--- a/mcelog.8
+++ b/mcelog.8
@@ -181,7 +181,13 @@ With the
 .B \-\-daemon
 option mcelog will run in the background. This gives the fastest reaction
 time and is the recommended operating mode.
-This option implies 
+If an output option isn't selected (
+.I \-\-logfile
+or
+.I \-\-syslog
+or
+.I \-\-syslog-error
+), this option implies
 .I \-\-logfile=/var/log/mcelog. 
 Important messages will be logged as one-liner summaries to syslog
 unless 

--- a/mcelog.c
+++ b/mcelog.c
@@ -1058,11 +1058,8 @@ static int modifier(int opt)
 		break;
 	case O_DAEMON:
 		daemon_mode = 1;
-		if (!logfile && !foreground)
-			logfile = logfile_default;
 		if (!(syslog_opt & SYSLOG_FORCE))
 			syslog_opt = SYSLOG_REMARK|SYSLOG_ERROR;
-
 		break;
 	case O_FILE:
 		inputfile = optarg;
@@ -1071,8 +1068,6 @@ static int modifier(int opt)
 		foreground = 1;	
 		if (!(syslog_opt & SYSLOG_FORCE))
 			syslog_opt = SYSLOG_FORCE;
-		if (logfile == logfile_default)
-			logfile = NULL;
 		break;
 	case O_NUMERRORS:
 		numerrors = atoi(optarg);
@@ -1096,6 +1091,9 @@ static int modifier(int opt)
 
 static void modifier_finish(void)
 {
+	if(!foreground && daemon_mode && !logfile && !(syslog_opt & SYSLOG_LOG)) {
+		logfile = logfile_default;
+	}
 	if (logfile) {
 		if (open_logfile(logfile) < 0) {
 			if (daemon_mode && !(syslog_opt & SYSLOG_FORCE))


### PR DESCRIPTION
The CPU detection code intended to only accept family 15 of AMD CPUs but
instead rejected all families >=15.  This patch corrects this logic and changes
the error message to suggest that the kernel module is a replacement, not a
supplement, for mcelog.
