### PR TITLE
Fix 'implicit declaration' warnings 

### DIFF
--- a/intel.c
+++ b/intel.c
@@ -22,6 +22,7 @@
 #include "nehalem.h"
 #include "memdb.h"
 #include "page.h"
+#include "sandy-bridge.h"
 #include "xeon75xx.h"
 
 int memory_error_support;

--- a/sandy-bridge.c
+++ b/sandy-bridge.c
@@ -21,6 +21,7 @@
 #include "mcelog.h"
 #include "bitfield.h"
 #include "sandy-bridge.h"
+#include "memdb.h"
 
 /* See IA32 SDM Vol3B Appendix E.4 ff */
 


### PR DESCRIPTION
This patch fixes two warnings that occurs during the compilation:

intel.c: In function ‘intel_memory_error’:
intel.c:102:4: warning: implicit declaration of function ‘sandy_bridge_ep_memerr_misc’

sandy-bridge.c: In function ‘failrank2dimm’:
sandy-bridge.c:103:3: warning: implicit declaration of function ‘get_memdimm’
