### PR TITLE
exit with EXIT_SUCCESS (aka 0) when stopped by signal

### DIFF
--- a/mcelog.c
+++ b/mcelog.c
@@ -856,7 +856,7 @@ static void remove_pidfile(void)
 static void signal_exit(int sig)
 {
 	remove_pidfile();
-	_exit(sig);
+	_exit(EXIT_SUCCESS);
 }
 
 static void setup_pidfile(char *s)


### PR DESCRIPTION
Rationale: When mcelog is running as a daemon, sending a SIGQUIT/SIGTERM/SIGINT is the only way to gracefully stop mcelog. This is especially useful in combination with systemd since systemd uses the exit value to detect if something got wrong.
