### PR TITLE
Add --intel-cpu to usage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean: test-clean
 	rm -f ${CLEAN} ${OBJ} 
 
 tsc:    tsc.c
-	gcc -o tsc ${CFLAGS} -DSTANDALONE tsc.c ${LDFLAGS}
+	$(CC) -o tsc ${CFLAGS} -DSTANDALONE tsc.c ${LDFLAGS}
 
 dbquery: db.o dbquery.o memutil.o
 
@@ -128,7 +128,7 @@ src:
 	echo $(SRC)
 
 config-test: config.c
-	gcc -DTEST=1 config.c -o config-test
+	$(CC) -DTEST=1 config.c -o config-test
 
 test:
 	$(MAKE) -C tests test DEBUG=""

--- a/mcelog.c
+++ b/mcelog.c
@@ -932,6 +932,7 @@ void usage(void)
 "Decode machine check ASCII output from kernel logs\n"
 "Options:\n"  
 "--cpu CPU           Set CPU type CPU to decode (see below for valid types)\n"
+"--intel-cpu FAMILY,MODEL  Set CPU type for an Intel CPU based on family and model from cpuid\n"
 "--cpumhz MHZ        Set CPU Mhz to decode time (output unreliable, not needed on new kernels)\n"
 "--raw		     (with --ascii) Dump in raw ASCII format for machine processing\n"
 "--daemon            Run in background waiting for events (needs newer kernel)\n"


### PR DESCRIPTION
Fixes issue #27 by making the existing option be known without reading the source.