### PR TITLE
mcelog hangs in the non-dameon mode when unknown error is encountered

### DIFF
--- a/trigger.c
+++ b/trigger.c
@@ -151,14 +151,13 @@ void trigger_setup(void)
 
 void trigger_wait(void)
 {
-	int sig;
-	sigset_t mask;
-	sigemptyset(&mask);
-	sigaddset(&mask, SIGCHLD);
-	while (num_children > 0) {
-		if (sigwait(&mask, &sig) < 0)
-			SYSERRprintf("sigwait waiting for children");
-	}
+	int status;
+	int pid;
+	
+	while ((pid = waitpid((pid_t)-1, &status, 0)) > 0) 
+		finish_child(pid, status);
+	
+	return 0;	
 }
 
 int trigger_check(char *s)


### PR DESCRIPTION
In the non-daemon mode, when the child processes exit the SIGCHLD
is being read off the queue, but the child handler is not called,
and the num_children is not decremented. This leads to the process
hanging in trigger_wait() function in an infinite loop waiting for
SIGCHLD signals that never arrive - (sigwait(&mask, &sig)).

This behaviour was discovered when the mcelog tried to process an
unknown error on a machine, and created child processes. The parent
process never exited. Since mcelog was run by a cron task every x
minutes, numerous hung-mcelog processes accumulated whenever it hit
the unknown-error-trigger.

Sample error lines:
mcelog: Running trigger unknown-error-trigger' mcelog: Running triggerunknown-error-trigger'
mcelog: CPU 5 on socket 0 received unknown error
mcelog: CPU 5 on socket 0 received unknown error

The fix is to call waitpid() to reap the exit status of all terminating
children, calling finish_child() for each. This fix has been tested
on the machine the issue was discovered on.

Signed-off-by: Tim Bingham tbingham@akamai.com
Signed-off-by: Sri Jayaramappa sjayaram@akamai.com