### PR TITLE
check return value of ‘asprintf’

### DIFF
--- a/mcelog.c
+++ b/mcelog.c
@@ -902,9 +902,11 @@ static void setup_pidfile(char *s)
 		c = getcwd(cwd, PATH_MAX);
 		if (!c)
 			return;
-		asprintf(&pidfile, "%s/%s", cwd, s);
+		else if (0 > asprintf(&pidfile, "%s/%s", cwd, s))
+			return;
 	} else {
-		asprintf(&pidfile, "%s", s);
+		if (0 > asprintf(&pidfile, "%s", s))
+			return;
 	}
 
 	return;


### PR DESCRIPTION
compiling with:
```sh
make CFLAGS='-Wall -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong --param ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security'
```
we can see many errors like this:
```
warning: ignoring return value of ‘asprintf’, declared with attribute warn_unused_result [-Wunused-result]
```

[checksec](http://www.trapkit.de/tools/checksec.html) status gets also better with this fixes.

See **without** these two fixes:
```sh
checksec --fortify-file mcelog
* FORTIFY_SOURCE support available (libc)    : Yes
* Binary compiled with FORTIFY_SOURCE support: Yes
[...]
SUMMARY:

* Number of checked functions in libc                : 78
* Total number of library functions in the executable: 814
* Number of FORTIFY-able functions in the executable : 48
* Number of checked functions in the executable      : 24
* Number of unchecked functions in the executable    : 24
```
against **with** the fixes,
```sh
SUMMARY:

* Number of checked functions in libc                : 78
* Total number of library functions in the executable: 807
* Number of FORTIFY-able functions in the executable : 44
* Number of checked functions in the executable      : 24
* Number of unchecked functions in the executable    : 20
```

Would you be interested in fixing all those issues?