### PR TITLE
Fix PDF links and remove trailing space and blank line in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ error predictive failure analysis) require a continuously running daemon.
 ## Documentation
 
 - The primary reference documentation are the man pages.
-- [lk10-mcelog.pdf](https://github.com/andikleen/mcelog/blob/master/lk10-mcelog.pdf)
+- [lk10-mcelog.pdf](lk10-mcelog.pdf)
   has a overview over the errors mcelog handles (originally from Linux Kongress 2010).
-- [mce.pdf](https://github.com/mjtrangoni/mcelog/blob/README.md/mce.pdf)
+- [mce.pdf](mce.pdf)
   is a very old paper describing the first releases of mcelog (some parts are obsolete).
 
 ## For distributors

--- a/README.releases
+++ b/README.releases
@@ -1,9 +1,8 @@
-
 mcelog used to do released, but now switched to a rolling release
 scheme. That means the git tree is always kept stable and can
 be used directly in production.
 
-To simplify package management which likes to have 
+To simplify package management which likes to have
 increasing version numbers the commits are regularly tagged
 with a number. The number starts (arbitarily) with 100.
 


### PR DESCRIPTION
Just found the broken links in `README.md` when reading the docs. Using relative paths fixes it here on GitHub, and should make it clear that the files are in the repo when reading elsewhere.

While at it, I cleaned up the blank line and trailing space in `README.releases`.