### PR TITLE
Fatal on -ENOMEM in vasprintf() to avoid undefined behavior

### DIFF
--- a/bus.c
+++ b/bus.c
@@ -62,23 +62,23 @@ void run_bus_trigger(int socket, int cpu, char *level, char *pp, char *rrrr,
 		return;
 
 	if (socket >= 0)
-		asprintf(&location, "CPU %d on socket %d", cpu, socket);
+		xasprintf(&location, "CPU %d on socket %d", cpu, socket);
 	else
-		asprintf(&location, "CPU %d", cpu);
-	asprintf(&msg, "%s received Bus and Interconnect Errors in %s",
+		xasprintf(&location, "CPU %d", cpu);
+	xasprintf(&msg, "%s received Bus and Interconnect Errors in %s",
 		location, ii);
-	asprintf(&env[ei++], "LOCATION=%s", location);
+	xasprintf(&env[ei++], "LOCATION=%s", location);
 	free(location);
 
 	if (socket >= 0)
-		asprintf(&env[ei++], "SOCKETID=%d", socket);
-	asprintf(&env[ei++], "MESSAGE=%s", msg);
-	asprintf(&env[ei++], "CPU=%d", cpu);
-	asprintf(&env[ei++], "LEVEL=%s", level);
-	asprintf(&env[ei++], "PARTICIPATION=%s", pp);
-	asprintf(&env[ei++], "REQUEST=%s", rrrr);
-	asprintf(&env[ei++], "ORIGIN=%s", ii);
-	asprintf(&env[ei++], "TIMEOUT=%s", timeout);
+		xasprintf(&env[ei++], "SOCKETID=%d", socket);
+	xasprintf(&env[ei++], "MESSAGE=%s", msg);
+	xasprintf(&env[ei++], "CPU=%d", cpu);
+	xasprintf(&env[ei++], "LEVEL=%s", level);
+	xasprintf(&env[ei++], "PARTICIPATION=%s", pp);
+	xasprintf(&env[ei++], "REQUEST=%s", rrrr);
+	xasprintf(&env[ei++], "ORIGIN=%s", ii);
+	xasprintf(&env[ei++], "TIMEOUT=%s", timeout);
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 
@@ -100,22 +100,22 @@ void run_iomca_trigger(int socket, int cpu, int seg, int bus, int dev, int fn)
 		return;
 
 	if (socket >= 0)
-		asprintf(&location, "CPU %d on socket %d", cpu, socket);
+		xasprintf(&location, "CPU %d on socket %d", cpu, socket);
 	else
-		asprintf(&location, "CPU %d", cpu);
-	asprintf(&msg, "%s received IO MCA Errors from %x:%02x:%02x.%x",
+		xasprintf(&location, "CPU %d", cpu);
+	xasprintf(&msg, "%s received IO MCA Errors from %x:%02x:%02x.%x",
 		location, seg, bus, dev, fn);
-	asprintf(&env[ei++], "LOCATION=%s", location);
+	xasprintf(&env[ei++], "LOCATION=%s", location);
 	free(location);
 
 	if (socket >= 0)
-		asprintf(&env[ei++], "SOCKETID=%d", socket);
-	asprintf(&env[ei++], "MESSAGE=%s", msg);
-	asprintf(&env[ei++], "CPU=%d", cpu);
-	asprintf(&env[ei++], "SEG=%x", seg);
-	asprintf(&env[ei++], "BUS=%02x", bus);
-	asprintf(&env[ei++], "DEVICE=%02x", dev);
-	asprintf(&env[ei++], "FUNCTION=%x", fn);
+		xasprintf(&env[ei++], "SOCKETID=%d", socket);
+	xasprintf(&env[ei++], "MESSAGE=%s", msg);
+	xasprintf(&env[ei++], "CPU=%d", cpu);
+	xasprintf(&env[ei++], "SEG=%x", seg);
+	xasprintf(&env[ei++], "BUS=%02x", bus);
+	xasprintf(&env[ei++], "DEVICE=%02x", dev);
+	xasprintf(&env[ei++], "FUNCTION=%x", fn);
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 

--- a/cache.c
+++ b/cache.c
@@ -126,7 +126,7 @@ static int read_caches(void)
 			int i;
 			int numindex;
 
-			asprintf(&fn, "%s/%s/cache", PREFIX, de->d_name);
+			xasprintf(&fn, "%s/%s/cache", PREFIX, de->d_name);
 			if (!stat(fn, &st)) {
 				numindex = st.st_nlink - 2;
 				if (numindex < 0)
@@ -139,7 +139,7 @@ static int read_caches(void)
 				for (i = 0; i < numindex; i++) {
 					char *cfn;
 					struct cache *c = caches[cpu] + i;
-					asprintf(&cfn, "%s/index%d", fn, i);
+					xasprintf(&cfn, "%s/index%d", fn, i);
 					c->type = read_field_map(cfn, "type", type_map);
 					c->level = read_field_num(cfn, "level");
 					read_cpu_map(c, cfn);

--- a/config.c
+++ b/config.c
@@ -104,9 +104,9 @@ static void unparseable(char *desc, const char *header, const char *name)
 	char *field;
 
 	if (!strcmp(header, "global")) { 
-		asprintf(&field, "%s", name);
+		xasprintf(&field, "%s", name);
 	} else { 
-		asprintf(&field, "[%s] %s", header, name);
+		xasprintf(&field, "[%s] %s", header, name);
 	}
 	Eprintf("%s config option `%s' unparseable\n", desc, field);
 	free(field);
@@ -293,7 +293,7 @@ int config_trigger(const char *header, const char *base, struct bucket_conf *bc)
 	char *name;
 	int n;
 
-	asprintf(&name, "%s-threshold", base);
+	xasprintf(&name, "%s-threshold", base);
 	s = config_string(header, name);
 	if (s) {
 		if (bucket_conf_init(bc, s) < 0) {
@@ -303,7 +303,7 @@ int config_trigger(const char *header, const char *base, struct bucket_conf *bc)
 	}
 	free(name);
 
-	asprintf(&name, "%s-trigger", base);
+	xasprintf(&name, "%s-trigger", base);
 	s = config_string(header, name);
 	if (s) { 
 		/* no $PATH */
@@ -316,7 +316,7 @@ int config_trigger(const char *header, const char *base, struct bucket_conf *bc)
 	free(name);
 
 	bc->log = 0;
-	asprintf(&name, "%s-log", base);
+	xasprintf(&name, "%s-log", base);
 	n = config_bool(header, name);
 	if (n >= 0)
 		bc->log = n;
@@ -330,7 +330,7 @@ void config_cred(char *header, char *base, struct config_cred *cred)
 	char *s;
 	char *name;
 
-	asprintf(&name, "%s-user", base);
+	xasprintf(&name, "%s-user", base);
 	if ((s = config_string(header, name)) != NULL) { 
 		struct passwd *pw;
 		if (!strcmp(s, "*"))
@@ -342,7 +342,7 @@ void config_cred(char *header, char *base, struct config_cred *cred)
 		        cred->uid = pw->pw_uid;
 	}
 	free(name);
-	asprintf(&name, "%s-group", base);	
+	xasprintf(&name, "%s-group", base);	
 	if ((s = config_string(header, name)) != NULL) { 
 		struct group *gr;
 		if (!strcmp(s, "*"))

--- a/leaky-bucket.c
+++ b/leaky-bucket.c
@@ -18,6 +18,7 @@
 #define _GNU_SOURCE 1
 #include <stdio.h>
 #include <ctype.h>
+#include "memutil.h"
 #include "leaky-bucket.h"
 
 time_t __attribute__((weak)) bucket_time(void)
@@ -85,12 +86,12 @@ char *bucket_output(const struct bucket_conf *c, struct leaky_bucket *b)
 {
 	char *buf;
 	if (c->capacity == 0) {
-		asprintf(&buf, "not enabled");
+		xasprintf(&buf, "not enabled");
 	} else { 
 		int unit = 0;
 		//bucket_age(c, b, bucket_time());
 		timeconv(c->tunit, &unit);
-		asprintf(&buf, "%u in %u%c", b->count + b->excess, 
+		xasprintf(&buf, "%u in %u%c", b->count + b->excess,
 			c->agetime/unit, c->tunit);
 	}
 	return buf;

--- a/mcelog.c
+++ b/mcelog.c
@@ -907,9 +907,9 @@ static void setup_pidfile(char *s)
 		c = getcwd(cwd, PATH_MAX);
 		if (!c)
 			return;
-		asprintf(&pidfile, "%s/%s", cwd, s);
+		xasprintf(&pidfile, "%s/%s", cwd, s);
 	} else {
-		asprintf(&pidfile, "%s", s);
+		xasprintf(&pidfile, "%s", s);
 	}
 
 	return;

--- a/memdb.c
+++ b/memdb.c
@@ -120,7 +120,7 @@ static char *format_location(struct memdimm *md)
 	char numbuf[NUMLEN], numbuf2[NUMLEN];
 	char *location;
 
-	asprintf(&location, "SOCKET:%d CHANNEL:%s DIMM:%s [%s%s%s]",
+	xasprintf(&location, "SOCKET:%d CHANNEL:%s DIMM:%s [%s%s%s]",
 		md->socketid, 
 		md->channel == -1 ? "?" : number(numbuf, md->channel),
 		md->dimm == -1 ? "?" : number(numbuf2, md->dimm),
@@ -142,34 +142,34 @@ void memdb_trigger(char *msg, struct memdimm *md,  time_t t,
 	char *thresh = bucket_output(bc, bucket);
 	char *out;
 
-	asprintf(&out, "%s: %s", msg, thresh);
+	xasprintf(&out, "%s: %s", msg, thresh);
 	if (bc->log) { 
 		Gprintf("%s\n", out); 
 		Gprintf("Location %s\n", location);
 	}
 	if (bc->trigger == NULL)
 		goto out;
-	asprintf(&env[ei++], "PATH=%s", getenv("PATH") ?: "/sbin:/usr/sbin:/bin:/usr/bin");
-	asprintf(&env[ei++], "THRESHOLD=%s", thresh);
-	asprintf(&env[ei++], "TOTALCOUNT=%lu", et->count);
-	asprintf(&env[ei++], "LOCATION=%s", location);
+	xasprintf(&env[ei++], "PATH=%s", getenv("PATH") ?: "/sbin:/usr/sbin:/bin:/usr/bin");
+	xasprintf(&env[ei++], "THRESHOLD=%s", thresh);
+	xasprintf(&env[ei++], "TOTALCOUNT=%lu", et->count);
+	xasprintf(&env[ei++], "LOCATION=%s", location);
 	if (md->location)
-		asprintf(&env[ei++], "DMI_LOCATION=%s", md->location);
+		xasprintf(&env[ei++], "DMI_LOCATION=%s", md->location);
 	if (md->name)
-		asprintf(&env[ei++], "DMI_NAME=%s", md->name);
+		xasprintf(&env[ei++], "DMI_NAME=%s", md->name);
 	if (md->dimm != -1)
-		asprintf(&env[ei++], "DIMM=%d", md->dimm);
+		xasprintf(&env[ei++], "DIMM=%d", md->dimm);
 	if (md->channel != -1)
-		asprintf(&env[ei++], "CHANNEL=%d", md->channel);
-	asprintf(&env[ei++], "SOCKETID=%d", md->socketid);
-	asprintf(&env[ei++], "CECOUNT=%lu", md->ce.count);
-	asprintf(&env[ei++], "UCCOUNT=%lu", md->uc.count);
+		xasprintf(&env[ei++], "CHANNEL=%d", md->channel);
+	xasprintf(&env[ei++], "SOCKETID=%d", md->socketid);
+	xasprintf(&env[ei++], "CECOUNT=%lu", md->ce.count);
+	xasprintf(&env[ei++], "UCCOUNT=%lu", md->uc.count);
 	if (t)
-		asprintf(&env[ei++], "LASTEVENT=%lu", t);
-	asprintf(&env[ei++], "AGETIME=%u", bc->agetime);
+		xasprintf(&env[ei++], "LASTEVENT=%lu", t);
+	xasprintf(&env[ei++], "AGETIME=%u", bc->agetime);
 	// XXX human readable version of agetime
-	asprintf(&env[ei++], "MESSAGE=%s", out);
-	asprintf(&env[ei++], "THRESHOLD_COUNT=%d", bucket->count);
+	xasprintf(&env[ei++], "MESSAGE=%s", out);
+	xasprintf(&env[ei++], "THRESHOLD_COUNT=%d", bucket->count);
 	env[ei] = NULL;	
 	assert(ei < MAX_ENV);
 	run_trigger(bc->trigger, NULL, env);
@@ -192,7 +192,7 @@ account_over(struct err_triggers *t, struct memdimm *md, struct mce *m, unsigned
 		md->ce.count += corr_err_cnt;
 		if (__bucket_account(&t->ce_bucket_conf, &md->ce.bucket, corr_err_cnt, m->time)) { 
 			char *msg;
-			asprintf(&msg, "Fallback %s memory error count %d exceeded threshold", 
+			xasprintf(&msg, "Fallback %s memory error count %d exceeded threshold",
 				 t->type, corr_err_cnt);
 			memdb_trigger(msg, md, 0, &md->ce, &t->ce_bucket_conf);
 			free(msg);
@@ -205,7 +205,7 @@ account_memdb(struct err_triggers *t, struct memdimm *md, struct mce *m)
 {
 	char *msg;
 
-	asprintf(&msg, "%scorrected %s memory error count exceeded threshold", 
+	xasprintf(&msg, "%scorrected %s memory error count exceeded threshold",
 		(m->status & MCI_STATUS_UC) ? "Un" : "", t->type);
 
 	if (m->status & MCI_STATUS_UC) { 

--- a/memutil.c
+++ b/memutil.c
@@ -71,7 +71,7 @@ int xvasprintf(char **strp, const char *fmt, va_list ap)
 	return n;
 }
 
-int asprintf(char **strp, const char *fmt, ...)
+int xasprintf(char **strp, const char *fmt, ...)
 {
 	int n;
 	va_list ap;

--- a/memutil.c
+++ b/memutil.c
@@ -62,15 +62,21 @@ char *xstrdup(char *str)
 	return str;
 }
 
-/* Override weak glibc version */
+int xvasprintf(char **strp, const char *fmt, va_list ap)
+{
+	int n;
+	n = vasprintf(strp, fmt, ap);
+	if (n < 0)
+		Enomem();
+	return n;
+}
+
 int asprintf(char **strp, const char *fmt, ...)
 {
 	int n;
 	va_list ap;
 	va_start(ap, fmt);
-	n = vasprintf(strp, fmt, ap);
+	n = xvasprintf(strp, fmt, ap);
 	va_end(ap);
-	if (n < 0) 
-		Enomem();
 	return n;
 }

--- a/memutil.h
+++ b/memutil.h
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
+int xasprintf(char **strp, const char *fmt, ...);
 int xvasprintf(char **ret, const char *format, va_list ap);
 void *xalloc(size_t size);
 void *xalloc_nonzero(size_t size);

--- a/memutil.h
+++ b/memutil.h
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
+int xvasprintf(char **ret, const char *format, va_list ap);
 void *xalloc(size_t size);
 void *xalloc_nonzero(size_t size);
 void *xrealloc(void *old, size_t size);

--- a/msg.c
+++ b/msg.c
@@ -97,7 +97,7 @@ void SYSERRprintf(char *fmt, ...)
 		char *fmt2;
 		va_start(ap, fmt);
 		opensyslog();
-		asprintf(&fmt2, "%s: %s\n", fmt, err);
+		xasprintf(&fmt2, "%s: %s\n", fmt, err);
 		vsyslog(LOG_ERR, fmt2, ap);
 		free(fmt2);
 		va_end(ap);

--- a/page.c
+++ b/page.c
@@ -214,7 +214,7 @@ void account_page_error(struct mce *m, int channel, int dimm)
 		/* Only do triggers and messages for online pages */
 		thresh = bucket_output(&page_trigger_conf, &mp->ce.bucket);
 		md = get_memdimm(m->socketid, channel, dimm, 1);
-		asprintf(&msg, "Corrected memory errors on page %llx exceed threshold %s",
+		xasprintf(&msg, "Corrected memory errors on page %llx exceed threshold %s",
 			addr, thresh);
 		free(thresh);
 		memdb_trigger(msg, md, t, &mp->ce, &page_trigger_conf);

--- a/sysfs.c
+++ b/sysfs.c
@@ -100,7 +100,7 @@ int sysfs_write(const char *name, const char *fmt, ...)
 	if (fd < 0)
 		return -1;
 	va_start(ap, fmt);
-	n = vasprintf(&buf, fmt, ap);
+	n = xvasprintf(&buf, fmt, ap);
 	va_end(ap);
 	n = write(fd, buf, n);
 	e = errno;

--- a/sysfs.c
+++ b/sysfs.c
@@ -35,7 +35,7 @@ char *read_field(char *base, char *name)
 	char *s;
 	char *buf = NULL;
 
-	asprintf(&fn, "%s/%s", base, name);
+	xasprintf(&fn, "%s/%s", base, name);
 	fd = open(fn, O_RDONLY);
 	free(fn);
 	if (fstat(fd, &st) < 0)

--- a/trigger.c
+++ b/trigger.c
@@ -164,7 +164,7 @@ int trigger_check(char *s)
 	int rc;
 
 	if (trigger_dir)
-		asprintf(&name, "%s/%s", trigger_dir, s);
+		xasprintf(&name, "%s/%s", trigger_dir, s);
 	else
 		name = s;
 

--- a/tsc.c
+++ b/tsc.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include "memutil.h"
 #include "mcelog.h"
 #include "tsc.h"
 #include "intel.h"
@@ -41,7 +42,7 @@ static int fmt_tsc(char **buf, u64 tsc, double mhz)
 	hours = scale(&tsc, 3600, mhz);
 	mins = scale(&tsc, 60, mhz);
 	secs = scale(&tsc, 1, mhz);
-	asprintf(buf, "[at %.0f Mhz %u days %u:%u:%u uptime (unreliable)]", 
+	xasprintf(buf, "[at %.0f Mhz %u days %u:%u:%u uptime (unreliable)]",
 		mhz, days, hours, mins, secs);
 	return 0;
 }
@@ -51,7 +52,7 @@ static double cpufreq_mhz(int cpu, double infomhz)
 	double mhz;
 	FILE *f;
 	char *fn;
-	asprintf(&fn, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpu);
+	xasprintf(&fn, "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpu);
 	f = fopen(fn, "r");
 	free(fn);
 	if (!f) {
@@ -83,13 +84,13 @@ static int deep_sleep_states(int cpu)
 	size_t linelen = 0;
 
 	/* When cpuidle is active assume there are deep sleep states */
-	asprintf(&fn, "/sys/devices/system/cpu/cpu%d/cpuidle", cpu);
+	xasprintf(&fn, "/sys/devices/system/cpu/cpu%d/cpuidle", cpu);
 	ret = access(fn, X_OK);
 	free(fn);
 	if (ret == 0)
 		return 1;
 
-	asprintf(&fn, "/proc/acpi/processor/CPU%d/power", cpu);
+	xasprintf(&fn, "/proc/acpi/processor/CPU%d/power", cpu);
 	f = fopen(fn, "r");
 	free(fn);
 	if (!f)

--- a/unknown.c
+++ b/unknown.c
@@ -54,22 +54,22 @@ void run_unknown_trigger(int socket, int cpu, struct mce *log)
 		return;
 
 	if (socket >= 0)
-		asprintf(&location, "CPU %d on socket %d", cpu, socket);
+		xasprintf(&location, "CPU %d on socket %d", cpu, socket);
 	else
-		asprintf(&location, "CPU %d", cpu);
-	asprintf(&msg, "%s received unknown error", location);
-	asprintf(&env[ei++], "LOCATION=%s", location);
+		xasprintf(&location, "CPU %d", cpu);
+	xasprintf(&msg, "%s received unknown error", location);
+	xasprintf(&env[ei++], "LOCATION=%s", location);
 	free(location);
 
 	if (socket >= 0)
-		asprintf(&env[ei++], "SOCKETID=%d", socket);
-	asprintf(&env[ei++], "MESSAGE=%s", msg);
-	asprintf(&env[ei++], "CPU=%d", cpu);
-	asprintf(&env[ei++], "STATUS=%llx", log->status);
-	asprintf(&env[ei++], "MISC=%llx", log->misc);
-	asprintf(&env[ei++], "ADDR=%llx", log->addr);
-	asprintf(&env[ei++], "MCGSTATUS=%llx", log->mcgstatus);
-	asprintf(&env[ei++], "MCGCAP=%llx", log->mcgcap);
+		xasprintf(&env[ei++], "SOCKETID=%d", socket);
+	xasprintf(&env[ei++], "MESSAGE=%s", msg);
+	xasprintf(&env[ei++], "CPU=%d", cpu);
+	xasprintf(&env[ei++], "STATUS=%llx", log->status);
+	xasprintf(&env[ei++], "MISC=%llx", log->misc);
+	xasprintf(&env[ei++], "ADDR=%llx", log->addr);
+	xasprintf(&env[ei++], "MCGSTATUS=%llx", log->mcgstatus);
+	xasprintf(&env[ei++], "MCGCAP=%llx", log->mcgcap);
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 

--- a/yellow.c
+++ b/yellow.c
@@ -69,10 +69,10 @@ void run_yellow_trigger(int cpu, int tnum, int lnum, char *ts, char *ls, int soc
 	char *location;
 
 	if (socket >= 0) 
-		asprintf(&location, "CPU %d on socket %d", cpu, socket);
+		xasprintf(&location, "CPU %d on socket %d", cpu, socket);
 	else
-		asprintf(&location, "CPU %d", cpu);
-	asprintf(&msg, "%s has large number of corrected cache errors in %s %s", 
+		xasprintf(&location, "CPU %d", cpu);
+	xasprintf(&msg, "%s has large number of corrected cache errors in %s %s",
 		location, ls, ts);
 	free(location);
 	if (yellow_log) {
@@ -83,15 +83,15 @@ void run_yellow_trigger(int cpu, int tnum, int lnum, char *ts, char *ls, int soc
 		goto out;
 
 	if (socket >= 0)
-		asprintf(&env[ei++], "SOCKETID=%d", socket);
-	asprintf(&env[ei++], "MESSAGE=%s", msg);
-	asprintf(&env[ei++], "CPU=%d", cpu);
-	asprintf(&env[ei++], "LEVEL=%d", lnum);
-	asprintf(&env[ei++], "TYPE=%s", ts);
+		xasprintf(&env[ei++], "SOCKETID=%d", socket);
+	xasprintf(&env[ei++], "MESSAGE=%s", msg);
+	xasprintf(&env[ei++], "CPU=%d", cpu);
+	xasprintf(&env[ei++], "LEVEL=%d", lnum);
+	xasprintf(&env[ei++], "TYPE=%s", ts);
 	if (cache_to_cpus(cpu, lnum, tnum, &cpumasklen, &cpumask) >= 0)
 		env[ei++] = cpulist("AFFECTED_CPUS=", cpumask, cpumasklen); 
 	else
-		asprintf(&env[ei++], "AFFECTED_CPUS=unknown");
+		xasprintf(&env[ei++], "AFFECTED_CPUS=unknown");
 	env[ei] = NULL;	
 	assert(ei < MAX_ENV);
 


### PR DESCRIPTION
The call to vasprintf in sysfs_write() is not wrapped to exit on OOM.

To fix this:

1. rename our version of asprintf to xasprintf to match the conventions in memutil.c
2. write our own xvasprintf and have xasprintf call it.
3. update sysfs_write() to use our new xvasprintf()

In addition, asprintf is wrapped, but not as per the conventions of memutil.c, instead it uses symbol overloading. It makes the code clearer and somewhat safer if we call our version xasprintf due to the call to exit(3) that it does. This change renames our asprintf to xasprintf to match the existing conventions of memutil.c and memutil.h. All calls to asprintf are then changed to calls to xasprintf to follow the renaming.
