### PR TITLE
Makefile: Make `git` check portable (POSIX compatible)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ depend: .depend
 
 version.tmp: FORCE
 	( echo -n "char version[] = \"" ; 	\
-	if type -p git >/dev/null; then 	\
+	if command -v git >/dev/null; then 	\
 	if [ -d .git ] ; then 			\
 		git describe --tags HEAD | tr -d '\n'; 	\
 	else 					\


### PR DESCRIPTION
Tested on Debian 9.0 (Stretch/testing).

Fixes: #42