### PR TITLE
Makefile: replace echo -n with printf for posix shell compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,15 +81,15 @@ depend: .depend
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $(WARNINGS) $(ADD_DEFINES) -o $@ $<
 
 version.tmp: FORCE
-	( echo -n "char version[] = \"" ; 	\
+	( printf "char version[] = \"" ; 	\
 	if command -v git >/dev/null; then 	\
 	if [ -d .git ] ; then 			\
 		git describe --tags HEAD | tr -d '\n'; 	\
 	else 					\
-		echo -n "unknown" ; 		\
+		printf "unknown" ; 		\
 	fi ;					\
-	else echo -n "unknown" ; fi ;		\
-	echo '";'				\
+	else printf "unknown" ; fi ;		\
+	printf '";\n'				\
 	 ) > version.tmp
 
 version.c: version.tmp

--- a/triggers/cache-error-trigger
+++ b/triggers/cache-error-trigger
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # cache error trigger. This shell script is executed by mcelog in daemon mode
 # when a CPU reports excessive corrected cache errors. This could be a indication
 # for future uncorrected errors.
@@ -23,7 +23,7 @@ for i in $AFFECTED_CPUS ; do
 	logger -s -p daemon.crit -t mcelog "Offlining CPU $i due to cache error threshold"
 	F=$(printf "/sys/devices/system/cpu/cpu%d/online" $i)
 	echo 0 > $F
-	if [ "$(< $F)" != "0" ] ; then
+	if [ "$(cat $F)" != "0" ] ; then
 		logger -s -p daemon.warn -t mcelog "Offlining CPU $i failed"
 		EXIT=1
 	fi


### PR DESCRIPTION
Shells like dash do not support the "-n" option on echo to suppress newline.
This patch replaces the echo calls with equivalent printf calls, this
should work on all POSIX shells.