### PR TITLE
memutil.h: add missing include for va_list

### DIFF
--- a/memutil.h
+++ b/memutil.h
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdarg.h>
 
 int xasprintf(char **strp, const char *fmt, ...);
 int xvasprintf(char **ret, const char *format, va_list ap);


### PR DESCRIPTION
Fixes compile error with uclibc-ng:

In file included from mcelog.c:51:0:
memutil.h:4:48: error: unknown type name 'va_list'
 int xvasprintf(char **ret, const char *format, va_list ap);

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>