### PR TITLE
Improve systemd service unit

### DIFF
--- a/mcelog.service
+++ b/mcelog.service
@@ -5,7 +5,6 @@ ConditionPathExists=!/sys/module/edac_mce_amd/initstate
 
 [Service]
 ExecStart=/usr/sbin/mcelog --ignorenodev --daemon --foreground
-StandardOutput=syslog
 SuccessExitStatus=0 15
 
 [Install]

--- a/mcelog.service
+++ b/mcelog.service
@@ -2,9 +2,10 @@
 Description=Machine Check Exception Logging Daemon
 After=syslog.target
 ConditionPathExists=!/sys/module/edac_mce_amd/initstate
+ConditionPathExists=/dev/mcelog
 
 [Service]
-ExecStart=/usr/sbin/mcelog --ignorenodev --daemon --foreground
+ExecStart=/usr/sbin/mcelog --daemon --foreground
 SuccessExitStatus=0 15
 
 [Install]

--- a/mcelog.service
+++ b/mcelog.service
@@ -3,9 +3,9 @@ Description=Machine Check Exception Logging Daemon
 After=syslog.target
 ConditionPathExists=!/sys/module/edac_mce_amd/initstate
 
-[Service] 
+[Service]
 ExecStart=/usr/sbin/mcelog --ignorenodev --daemon --foreground
-StandardOutput=syslog 
+StandardOutput=syslog
 SuccessExitStatus=0 15
 
 [Install]


### PR DESCRIPTION
Unfortunately, it’s not trivial to only start the service when `mcelog --is-cpu-supported` returns true, so
that the service unit doesn’t show up as failed. A separate script would probably be needed for that.