### PR TITLE
mcelog: Do not start mcelog service if edac_mce_amd module is loaded

### DIFF
--- a/mcelog.service
+++ b/mcelog.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Machine Check Exception Logging Daemon
 After=syslog.target
+ConditionPathExists=!/sys/module/edac_mce_amd/initstate
 
 [Service] 
 ExecStart=/usr/sbin/mcelog --ignorenodev --daemon --foreground


### PR DESCRIPTION
Do not start the mcelog service if the edac_mce_amd module is already
loaded.  This can be done by adding a condition check for the
/sys/module/edac_mce_amd/initstate file.

Signed-off-by: Prarit Bhargava <prarit@redhat.com>