### PR TITLE
Proposal: add information about which path reported a MCE event

### DIFF
--- a/bus.c
+++ b/bus.c
@@ -82,7 +82,7 @@ void run_bus_trigger(int socket, int cpu, char *level, char *pp, char *rrrr,
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 
-	run_trigger(bus_trigger, NULL, env, false);
+	run_trigger(bus_trigger, NULL, env, false, "bus");
 	for (i = 0; i < ei; i++)
 		free(env[i]);
 	free(msg);
@@ -119,7 +119,7 @@ void run_iomca_trigger(int socket, int cpu, int seg, int bus, int dev, int fn)
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 
-	run_trigger(iomca_trigger, NULL, env, false);
+	run_trigger(iomca_trigger, NULL, env, false, "iomca");
 	for (i = 0; i < ei; i++)
 		free(env[i]);
 	free(msg);

--- a/dimm.c
+++ b/dimm.c
@@ -374,7 +374,7 @@ void new_error(unsigned long long addr, unsigned long max_error, char *trigger)
 			Lprintf("Large number of corrected errors in memory at %s", loc);
 			Lprintf("Consider replacing it");
 			if (trigger && trigger[0])
-				run_trigger(trigger, loc, val, max_error, false);
+				run_trigger(trigger, loc, val, max_error, false, "dimm");
 		}
 	}
 	free(devs);

--- a/memdb.h
+++ b/memdb.h
@@ -20,5 +20,6 @@ void memory_error(struct mce *m, int channel, int dimm, unsigned corr_err_cnt,
 
 struct memdimm;
 void memdb_trigger(char *msg, struct memdimm *md,  time_t t,
-		   struct err_type *et, struct bucket_conf *bc, char *argv[], bool sync);
+		   struct err_type *et, struct bucket_conf *bc, char *argv[], bool sync,
+           const char* reporter);
 struct memdimm *get_memdimm(int socketid, int channel, int dimm, int insert);

--- a/page.c
+++ b/page.c
@@ -220,7 +220,7 @@ void account_page_error(struct mce *m, int channel, int dimm)
 		xasprintf(&msg, "Corrected memory errors on page %llx exceed threshold %s",
 			addr, thresh);
 		free(thresh);
-		memdb_trigger(msg, md, t, &mp->ce, &page_trigger_conf, NULL, false);
+		memdb_trigger(msg, md, t, &mp->ce, &page_trigger_conf, NULL, false, "page");
 		free(msg);
 		mp->triggered = 1;
 
@@ -241,7 +241,7 @@ void account_page_error(struct mce *m, int channel, int dimm)
 			argv[0]=page_error_pre_soft_trigger;
 			argv[1]=args;
 			asprintf(&msg, "pre soft trigger run for page %lld", addr);
-			memdb_trigger(msg, md, t, &mp->ce, &page_soft_trigger_conf, argv, true);
+			memdb_trigger(msg, md, t, &mp->ce, &page_soft_trigger_conf, argv, true, "page_pre_soft");
 			free(msg);
 
 			offline_action(mp, addr);
@@ -251,7 +251,7 @@ void account_page_error(struct mce *m, int channel, int dimm)
 			argv[0]=page_error_post_soft_trigger;
 			argv[1]=args;
 			asprintf(&msg, "post soft trigger run for page %lld", addr);
-			memdb_trigger(msg, md, t, &mp->ce, &page_soft_trigger_conf, argv, true);
+			memdb_trigger(msg, md, t, &mp->ce, &page_soft_trigger_conf, argv, true, "page_post_soft");
 			free(msg);
 			free(args);
 

--- a/tests/test
+++ b/tests/test
@@ -61,7 +61,7 @@ do
 
 	if [ "$NUMT" != "" ] ; then
 		if [ "$NUMC" != "$NUMT" ] ; then
-			echo "$conf: triggers did not trigger as expected: $NUMT != $NUMC" >> results
+			echo "$conf: triggers did not trigger as expected: expected $NUMT, got $NUMC" >> results
 		else
 			echo "$conf: triggers trigger as expected" >> results
 		fi

--- a/trigger.c
+++ b/trigger.c
@@ -61,7 +61,7 @@ pid_t mcelog_fork(const char *name)
 }
 
 // note: trigger must be allocated, e.g. from config
-void run_trigger(char *trigger, char *argv[], char **env, bool sync)
+void run_trigger(char *trigger, char *argv[], char **env, bool sync, const char* reporter)
 {
 	pid_t child;
 
@@ -73,7 +73,7 @@ void run_trigger(char *trigger, char *argv[], char **env, bool sync)
 	if (!argv) 
 		argv = fallback_argv;
 
-	Lprintf("Running trigger `%s'\n", trigger);	
+	Lprintf("Running trigger `%s' (reporter: %s)\n", trigger, reporter);
 	if (children_max > 0 && num_children >= children_max) { 
 		Eprintf("Too many trigger children running already\n");
 		return;

--- a/trigger.h
+++ b/trigger.h
@@ -2,7 +2,7 @@
 #define __TRIGGER_H__
 
 #include <stdbool.h>
-void run_trigger(char *trigger, char *argv[], char **env, bool sync);
+void run_trigger(char *trigger, char *argv[], char **env, bool sync, const char* reporter);
 void trigger_setup(void);
 void trigger_wait(void);
 int trigger_check(char *);

--- a/unknown.c
+++ b/unknown.c
@@ -73,7 +73,7 @@ void run_unknown_trigger(int socket, int cpu, struct mce *log)
 	env[ei] = NULL;
 	assert(ei < MAX_ENV);
 
-	run_trigger(unknown_trigger, NULL, env, false);
+	run_trigger(unknown_trigger, NULL, env, false, "unknown");
 	for (i = 0; i < ei; i++)
 		free(env[i]);
 	free(msg);

--- a/yellow.c
+++ b/yellow.c
@@ -95,7 +95,7 @@ void run_yellow_trigger(int cpu, int tnum, int lnum, char *ts, char *ls, int soc
 	env[ei] = NULL;	
 	assert(ei < MAX_ENV);
 
-	run_trigger(yellow_trigger, NULL, env, false);
+	run_trigger(yellow_trigger, NULL, env, false, "yellow");
 	for (i = 0; i < ei; i++)
 		free(env[i]);
 out:


### PR DESCRIPTION
Hi,
during testing mcelog at RedHat, I got an idea it might be good for the user to get exact info about which path of mcelog code processed an event and called the trigger script, i.e. whether the cause was a socket, a DIMM, soft-page-offline etc. (this also helps with testing).
Please see the proposed changes below...
Thanks for considering this!
JD