### PR TITLE
test: avoid the pfa test hang

### DIFF
--- a/tests/test
+++ b/tests/test
@@ -47,6 +47,9 @@ do
 	# Inject mce records and run mcelog in parallel.
 	# So that the mce records can be consumed by mcelog in time (avoid mce record overflow).
 	./inject $conf &
+	if [ "$1" = "pfa" ] ; then
+		which page-types > /dev/null 2>&1 || continue
+	fi
 	$D ../../mcelog --foreground --daemon --debug-numerrors --config $conf --logfile $log >> result
 
 	# let triggers finish


### PR DESCRIPTION
Per [1], the pfa test needs to install page-types and the pfa test
will hang forever if there is no page-types installed.

Improve the test script to avoid the pfa test hang.

[1] https://git.kernel.org/pub/scm/utils/cpu/mce/mcelog.git/tree/tests/pfa/PFA_test_howto?id=7b776a8c005b60572f49797e81287540f99fff1f

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>