### PR TITLE
fix the buf not free in read_field

### DIFF
--- a/sysfs.c
+++ b/sysfs.c
@@ -39,7 +39,7 @@ char *read_field(char *base, char *name)
 	fd = open(fn, O_RDONLY);
 	free(fn);
 	if (fd < 0)
-		goto bad;
+		goto bad_buf;
 	n = read(fd, buf, 4096);
 	close(fd);
 	if (n < 0)


### PR DESCRIPTION
#97 
When the value of fd is < 0, jump to bad_buf, release the memory of buf to prevent memory leakage.