### PR TITLE
Make genconfig use python3

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -1,7 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # generate man config documentation from mcelog.conf example
 # genconfig.py mcelog.conf intro.html
-from __future__ import print_function
 import sys
 import re
 import argparse


### PR DESCRIPTION
Use python3 instead of python executable which is the default nowadays