### PR TITLE
Use env as the shebang target

### DIFF
--- a/genconfig.py
+++ b/genconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # generate man config documentation from mcelog.conf example
 # genconfig.py mcelog.conf intro.html
 import sys


### PR DESCRIPTION
Let the script be flexible when it comes to finding the python3
interpreter.

Some build wrappers, such as buildroot, will provide a python3 binary
for use by scripts but it will not be at the fixed path of /usr/bin/.
Instead it will be available in a path defined in $PATH

Using env as the shebang target with python3 as the command will follow
$PATH search priority when determining the python3 interpreter.

Fixes #107 