### PR TITLE
client.c: fix build w/ musl libc

### DIFF
--- a/client.c
+++ b/client.c
@@ -19,6 +19,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <string.h>
 #include "mcelog.h"
 #include "client.h"
 #include "paths.h"


### PR DESCRIPTION
Without the patch, I'm getting the following error:

```
client.c:47:2: error: call to undeclared library function 'strncpy' with type
      'char *(char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations
      [-Wimplicit-function-declaration]
        strncpy(sun.sun_path, path, sizeof(sun.sun_path)-1);
        ^
client.c:47:2: note: include the header <string.h> or explicitly provide a declaration for 'strncpy'
client.c:60:19: error: call to undeclared library function 'memcmp' with type 'int
      (const void *, const void *, unsigned long)'; ISO C99 and later do not support implicit function declarations
      [-Wimplicit-function-declaration]
                        if (n >= 5 && !memcmp(buf + n - 5, "done\n", 5)) {
                                       ^
client.c:60:19: note: include the header <string.h> or explicitly provide a declaration for 'memcmp'
2 errors generated.
```