### PR TITLE
add --ping option to mcelog client

### DIFF
--- a/client.c
+++ b/client.c
@@ -64,6 +64,12 @@ void ask_server(char *command)
 			}
 
 			fputs(buf, stdout);
+
+			/* we want to show the string pong before exiting the loop */
+			if (n >= 5 && !memcmp(buf + n - 5, "pong\n", 5)) {
+				fclose(fp);
+				return;
+			}
 		}
 		fclose(fp);
 	}

--- a/client.c
+++ b/client.c
@@ -65,10 +65,8 @@ void ask_server(char *command)
 
 			fputs(buf, stdout);
 
-			/* we want to show the string pong before exiting the loop */
 			if (n >= 5 && !memcmp(buf + n - 5, "pong\n", 5)) {
-				fclose(fp);
-				return;
+				fflush(stdout);
 			}
 		}
 		fclose(fp);

--- a/mcelog.8
+++ b/mcelog.8
@@ -18,6 +18,8 @@ mcelog [options] \-\-ascii
 .br
 mcelog [options] \-\-is\-cpu\-supported
 .br
+mcelog \-\-ping
+.br
 mcelog \-\-version
 .SH DESCRIPTION
 X86 CPUs report errors detected by the CPU as
@@ -238,6 +240,13 @@ not to with the
 .B \-\-no-imc-log
 option. You might need this option when decoding old logs
 from a system where this mode was not enabled.
+
+Users can utilize the 
+.B \-\-ping
+option to check the availability of the mcelog server. If the mcelog server 
+is running, the command returns the string 
+.I pong
+followed by a newline character.
 
 .\".B \-\-database filename
 .\"specifies the memory module error database file. Default is

--- a/mcelog.c
+++ b/mcelog.c
@@ -886,6 +886,7 @@ void usage(void)
 "--raw		     (with --ascii) Dump in raw ASCII format for machine processing\n"
 "--daemon            Run in background waiting for events (needs newer kernel)\n"
 "--client            Query a currently running mcelog daemon for errors\n"
+"--ping              Send ping command to the currently running mcelog daemon\n"
 "--ignorenodev       Exit silently when the device cannot be opened\n"
 "--file filename     With --ascii read machine check log from filename instead of stdin\n"
 "--logfile filename  Log decoded machine checks in file filename\n"
@@ -930,6 +931,7 @@ enum options {
 	O_DAEMON,
 	O_ASCII,
 	O_CLIENT,
+	O_PING,
 	O_VERSION,
 	O_CONFIG_FILE,
 	O_CPU,
@@ -971,6 +973,7 @@ static struct option options[] = {
 	{ "cpu", 1, NULL, O_CPU },
 	{ "foreground", 0, NULL, O_FOREGROUND },
 	{ "client", 0, NULL, O_CLIENT },
+	{ "ping", 0, NULL, O_PING },
 	{ "num-errors", 1, NULL, O_NUMERRORS },
 	{ "pidfile", 1, NULL, O_PIDFILE },
 	{ "debug-numerrors", 0, NULL, O_DEBUG_NUMERRORS }, /* undocumented: for testing */
@@ -1276,8 +1279,16 @@ static void client_command(int ac, char **av)
 	argsleft(ac, av);
 	no_syslog();
 	// XXX modifiers
-	ask_server("dump all bios\n");		
+	ask_server("dump all bios\n");
 	ask_server("pages\n");
+}
+
+static void ping_command(int ac, char **av)
+{
+	argsleft(ac, av);
+	no_syslog();
+	// XXX modifiers
+	ask_server("ping\n");
 }
 
 struct mcefd_data {
@@ -1312,13 +1323,16 @@ int main(int ac, char **av)
 			exit(1);
 		} else if (combined_modifier(opt) > 0) {
 			continue;
-		} else if (opt == O_ASCII) { 
+		} else if (opt == O_ASCII) {
 			ascii_command(ac, av);
 			exit(0);
-		} else if (opt == O_CLIENT) { 
+		} else if (opt == O_CLIENT) {
 			client_command(ac, av);
 			exit(0);
-		} else if (opt == O_VERSION) { 
+		} else if (opt == O_PING) {
+			ping_command(ac, av);
+			exit(0);
+		} else if (opt == O_VERSION) {
 			noargs(ac, av);
 			fprintf(stderr, "mcelog %s\n", MCELOG_VERSION);
 			exit(0);


### PR DESCRIPTION
This pull request introduces a new functionality to the `mcelog` command, an option enabling the execution of the `ping` command. This addition allows users to verify the readiness of the mcelog server before initiating other commands.

example:

```shell
#!/bin/bash

MCELOG_PING=$(mcelog --ping)

if [[ "$MCELOG_PING" == "pong" ]]
then
    echo "mcelog server is up"
else
    echo "mcelog server is not up"
fi
```