### PR TITLE
add listen backlog config for mcelog server

### DIFF
--- a/mcelog.conf
+++ b/mcelog.conf
@@ -93,7 +93,10 @@ client-user = root
 # When mcelog starts it checks if a server is already running. This configures the timeout
 # for this check.
 #initial-ping-timeout = 2 
-#
+# Listen backlog for the unix socket.
+# default: 10
+#listen-backlog = 10
+
 [dimm]
 # Is the in memory DIMM error tracking enabled?
 # Only works on systems with integrated memory controller and


### PR DESCRIPTION
this patch makes the listen backlog of the unix domain socket adjustable. a new config option `listen-backlog` is added in the `mcelog.conf` under the `server` header. the default backlog is still `10` which is the original value if the option is not enabled.

example:

`mcelog.conf` content:

```
[server]
client-user = root
socket-path = /var/run/mcelog-client
listen-backlog = 200
```

`ss` command output:

```
Netid State  Recv-Q Send-Q                                            Local Address:Port      Peer Address:PortProcess                                                                                                     
...
u_str LISTEN 0      200                                      /var/run/mcelog-client 276537623            * 0    users:(("mcelog",pid=1704402,fd=4))                                                                        
```